### PR TITLE
Fix indexing of ground truth in PRM process reward

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1140,7 +1140,7 @@ class RayPPOTrainer:
                                     process_rewards.append(0.0)
                                     continue
                                 idx = sample_index[i].item()
-                                gt = original_batch.non_tensor_batch["reward_model"]["ground_truth"][idx]
+                                gt = original_batch.non_tensor_batch["reward_model"][idx]["ground_truth"]
                                 question = original_batch.non_tensor_batch.get("prompt", None)
                                 if question is not None:
                                     question = question[idx]


### PR DESCRIPTION
## Summary
- fix ground truth indexing during process reward calculation

## Testing
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68694c2608b48320af90522713141201