### PR TITLE
Add retry with logging for PRM compute_score

### DIFF
--- a/verl/utils/reward_score/process_reward.py
+++ b/verl/utils/reward_score/process_reward.py
@@ -10,6 +10,7 @@ invoked with a short yes/no prompt and returns ``1.0`` if the answer begins with
 from __future__ import annotations
 
 import os
+import time
 from typing import Any, Dict, Iterable
 
 try:  # Optional dependency
@@ -18,6 +19,34 @@ except Exception:  # pragma: no cover - optional dependency might be missing
     OpenAI = None  # type: ignore
 
 _CLIENT = None
+
+# Maximum retry attempts for API call. Can be overridden by environment variable
+MAX_RETRY = int(os.environ.get("PRM_RETRY", "3"))
+# Seconds to wait between retries
+RETRY_INTERVAL = float(os.environ.get("PRM_RETRY_INTERVAL", "1"))
+
+
+def _log_failure_to_dashboard(message: str) -> None:
+    """Log failure message to tensorboard or swanlab if available."""
+    # Tensorboard logging
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+
+        tensorboard_dir = os.environ.get("TENSORBOARD_DIR", "tensorboard_log")
+        os.makedirs(tensorboard_dir, exist_ok=True)
+        writer = SummaryWriter(tensorboard_dir)
+        writer.add_text("prm/failure", message)
+        writer.close()
+    except Exception:
+        pass
+
+    # Swanlab logging
+    try:
+        import swanlab
+
+        swanlab.log({"prm/failure": swanlab.Text(message)}, step=0)
+    except Exception:
+        pass
 
 
 def _get_client() -> Any:
@@ -72,17 +101,21 @@ def compute_score(solution_str: str, ground_truth, extra_info: Dict[str, Any] | 
         f"Memory: {solution_str}"
     )
 
-    try:
-        client = _get_client()
-        completion = client.chat.completions.create(
-            model=os.environ.get("PRM_OPENAI_MODEL", "gpt-3.5-turbo"),
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,
-            max_tokens=1,
-        )
-        content = completion.choices[0].message.content.strip().lower()
-        return 1.0 if content.startswith("yes") else 0.0
-    except Exception as exc:  # pragma: no cover - network call
-        print(f"Process reward model failed: {exc}")
-        return 0.0
+    for attempt in range(1, MAX_RETRY + 1):
+        try:
+            client = _get_client()
+            completion = client.chat.completions.create(
+                model=os.environ.get("PRM_OPENAI_MODEL", "gpt-3.5-turbo"),
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.0,
+                max_tokens=1,
+            )
+            content = completion.choices[0].message.content.strip().lower()
+            return 1.0 if content.startswith("yes") else 0.0
+        except Exception as exc:  # pragma: no cover - network call
+            print(f"Process reward attempt {attempt} failed: {exc}")
+            if attempt >= MAX_RETRY:
+                _log_failure_to_dashboard(str(exc))
+                return 0.0
+            time.sleep(RETRY_INTERVAL)
 


### PR DESCRIPTION
## Summary
- improve PRM reward handler by retrying API calls
- if all retries fail, log the error to tensorboard or swanlab and return zero reward

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6869dc2fad108320987e731c373c49b9