### PR TITLE
Use unified env vars for PRM logging

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -966,6 +966,7 @@ class RayPPOTrainer:
         from omegaconf import OmegaConf
 
         from verl.utils.tracking import Tracking
+        from verl.utils.reward_score import process_reward
 
         logger = Tracking(
             project_name=self.config.trainer.project_name,
@@ -973,6 +974,10 @@ class RayPPOTrainer:
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
         )
+
+        # Configure the process reward model with the same tracking settings
+        process_reward.set_config(self.config)
+        process_reward.set_logger(logger)
 
         self.global_steps = 0
 


### PR DESCRIPTION
## Summary
- standardize PRM env variable names with VERL_PRM prefix
- log detailed PRM failure info including prompt and attempt number
- connect PRM tracker to trainer config for unified logging
- allow trainer to pass its logger directly to PRM
- remove environment variable fallback when constructing the PRM tracker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6869dc2fad108320987e731c373c49b9